### PR TITLE
feat(dom): 添加 DOMHelper 工具类及其测试

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-tsdoc": "^0.4.0",
     "fast-glob": "^3.3.3",
     "git-cz": "^4.9.0",
+    "happy-dom": "^17.4.4",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
     "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       '@vitest/coverage-v8':
         specifier: ^3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 3.0.9(vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
       '@vitest/ui':
         specifier: ^3.0.9
         version: 3.0.9(vitest@3.0.9)
@@ -83,6 +83,9 @@ importers:
       git-cz:
         specifier: ^4.9.0
         version: 4.9.0
+      happy-dom:
+        specifier: ^17.4.4
+        version: 17.4.4
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -139,7 +142,7 @@ importers:
         version: 1.6.3(@algolia/client-search@5.21.0)(@types/node@22.13.10)(postcss@8.5.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.2)
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
 
 packages:
 
@@ -3075,6 +3078,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  happy-dom@17.4.4:
+    resolution: {integrity: sha512-/Pb0ctk3HTZ5xEL3BZ0hK1AqDSAUuRQitOmROPHhfUYEWpmTImwfD8vFDGADmMAX0JYgbcgxWoLFKtsWhcpuVA==}
+    engines: {node: '>=18.0.0'}
+
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -5214,6 +5221,14 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
@@ -7162,7 +7177,7 @@ snapshots:
       vite: 5.4.14(@types/node@22.13.10)(terser@5.39.0)
       vue: 3.5.13(typescript@5.8.2)
 
-  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -7176,7 +7191,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+      vitest: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7223,7 +7238,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+      vitest: 3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
 
   '@vitest/utils@3.0.9':
     dependencies:
@@ -8759,6 +8774,11 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
+
+  happy-dom@17.4.4:
+    dependencies:
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   has-bigints@1.0.2: {}
 
@@ -10878,7 +10898,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0):
+  vitest@3.0.9(@types/node@22.13.10)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.9
       '@vitest/mocker': 3.0.9(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
@@ -10903,6 +10923,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       '@vitest/ui': 3.0.9(vitest@3.0.9)
+      happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti
       - less
@@ -10932,6 +10953,10 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './modules/array'
 export * from './modules/bytes'
 export * from './modules/config/rollup'
+export * from './modules/dom'
 export * from './modules/enum'
 export * from './modules/error'
 export * from './modules/fp'

--- a/src/modules/dom.ts
+++ b/src/modules/dom.ts
@@ -1,0 +1,112 @@
+export class DOMHelper {
+  constructor(private selector: string | HTMLElement) {}
+
+  // 获取元素
+  get(): HTMLElement | null {
+    return typeof this.selector === 'string'
+      ? document.querySelector(this.selector)
+      : this.selector
+  }
+
+  // 获取元素文本内容
+  text(defaultValue = ''): string {
+    return this.get()?.textContent?.trim() || defaultValue
+  }
+
+  // 获取元素属性
+  attr(attrName: string, defaultValue = ''): string {
+    return this.get()?.getAttribute(attrName) || defaultValue
+  }
+
+  // 获取表单元素值（改进类型）
+  val<T extends string | number | boolean>(defaultValue?: T): T | string {
+    const el = this.get() as HTMLInputElement
+    if (!el) return defaultValue as T
+
+    if (typeof defaultValue === 'number') {
+      const num = Number(el.value)
+      return (isNaN(num) ? defaultValue : num) as T
+    }
+    if (typeof defaultValue === 'boolean') {
+      return (el.value === 'true') as T
+    }
+    return el.value as T
+  }
+
+  // 设置元素文本
+  setText(text: string): this {
+    const el = this.get()
+    if (el) el.textContent = text
+    return this
+  }
+
+  // 设置元素属性
+  setAttr(attrName: string, value: string): this {
+    this.get()?.setAttribute(attrName, value)
+    return this
+  }
+
+  // 添加/移除 CSS 类
+  addClass(className: string): this {
+    this.get()?.classList.add(className)
+    return this
+  }
+
+  removeClass(className: string): this {
+    this.get()?.classList.remove(className)
+    return this
+  }
+
+  toggleClass(className: string): this {
+    this.get()?.classList.toggle(className)
+    return this
+  }
+
+  // 检查元素是否存在
+  exists(): boolean {
+    return this.get() !== null
+  }
+
+  // 静态方法创建实例
+  static $(selector: string): DOMHelper {
+    return new DOMHelper(selector)
+  }
+
+  // 事件绑定/解绑
+  private eventHandlers = new Map<string, EventListener>()
+
+  on(event: string, handler: EventListener): this {
+    const el = this.get()
+    if (el) {
+      this.eventHandlers.set(event, handler)
+      el.addEventListener(event, handler)
+    }
+    return this
+  }
+
+  off(event: string): this {
+    const el = this.get()
+    const handler = this.eventHandlers.get(event)
+    if (el && handler) {
+      el.removeEventListener(event, handler)
+      this.eventHandlers.delete(event)
+    }
+    return this
+  }
+
+  // 链式操作父/子元素
+  parent(): DOMHelper | null {
+    const parent = this.get()?.parentElement
+    return parent ? new DOMHelper(parent) : null
+  }
+
+  children(selector?: string): DOMHelper[] {
+    const children = selector
+      ? Array.from(this.get()?.querySelectorAll(selector) || [])
+      : Array.from(this.get()?.children || [])
+    return children.map((el) => new DOMHelper(el as HTMLElement))
+  }
+}
+
+// 保留原有的 $ 对象导出
+export const $ = DOMHelper.$

--- a/test/dom.test.ts
+++ b/test/dom.test.ts
@@ -1,0 +1,113 @@
+import { $, DOMHelper } from '@mudssky/jsutils'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+/**
+ * @vitest-environment happy-dom
+ */
+describe('DOMHelper', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="test" class="box" data-id="123">Test Content</div>
+      <input id="input" value="initial">
+      <div class="parent">
+        <div class="child">Child 1</div>
+        <div class="child">Child 2</div>
+      </div>
+    `
+    document.body.appendChild(container)
+  })
+
+  test('constructor with selector string', () => {
+    const helper = new DOMHelper('#test')
+    expect(helper.exists()).toBe(true)
+  })
+
+  test('constructor with HTMLElement', () => {
+    const el = document.getElementById('test')!
+    const helper = new DOMHelper(el)
+    expect(helper.exists()).toBe(true)
+  })
+
+  test('get() returns element', () => {
+    const helper = new DOMHelper('#test')
+    expect(helper.get()).toBeInstanceOf(HTMLElement)
+  })
+
+  test('text() gets text content', () => {
+    const helper = new DOMHelper('#test')
+    expect(helper.text()).toBe('Test Content')
+    expect(helper.text('default')).toBe('Test Content')
+  })
+
+  test('attr() gets attribute', () => {
+    const helper = new DOMHelper('#test')
+    expect(helper.attr('data-id')).toBe('123')
+    expect(helper.attr('nonexistent', 'default')).toBe('default')
+  })
+
+  test('val() gets input value', () => {
+    const helper = new DOMHelper('#input')
+    expect(helper.val('default')).toBe('initial')
+    expect(helper.val<string>('default')).toBe('initial')
+    expect(helper.val<number>(0)).toBe(0) // 测试数字类型
+  })
+
+  test('setText() updates text content', () => {
+    const helper = new DOMHelper('#test')
+    helper.setText('New Content')
+    expect(helper.text()).toBe('New Content')
+  })
+
+  test('setAttr() updates attribute', () => {
+    const helper = new DOMHelper('#test')
+    helper.setAttr('data-id', '456')
+    expect(helper.attr('data-id')).toBe('456')
+  })
+
+  test('class operations', () => {
+    const helper = new DOMHelper('#test')
+    helper.addClass('active')
+    expect(helper.get()?.classList.contains('active')).toBe(true)
+
+    helper.removeClass('box')
+    expect(helper.get()?.classList.contains('box')).toBe(false)
+
+    helper.toggleClass('toggle')
+    expect(helper.get()?.classList.contains('toggle')).toBe(true)
+  })
+
+  test('event handling', () => {
+    const helper = new DOMHelper('#test')
+    let clicked = false
+    const handler = () => (clicked = true)
+
+    helper.on('click', handler)
+    helper.get()?.click()
+    expect(clicked).toBe(true)
+
+    clicked = false
+    helper.off('click')
+    helper.get()?.click()
+    expect(clicked).toBe(false)
+  })
+
+  test('parent() returns parent helper', () => {
+    const helper = new DOMHelper('.child')
+    expect(helper.parent()?.get()?.classList.contains('parent')).toBe(true)
+  })
+
+  test('children() returns child helpers', () => {
+    const helper = new DOMHelper('.parent')
+    expect(helper.children().length).toBe(2)
+    expect(helper.children('.child').length).toBe(2)
+  })
+
+  test('$ static method', () => {
+    const helper = $('#test')
+    helper.setText('Test Content')
+    expect(helper.text()).toBe('Test Content')
+  })
+})


### PR DESCRIPTION
添加 DOMHelper 工具类，用于简化 DOM 操作，支持元素选择、属性操作、事件绑定等功能。同时添加相应的单元测试，确保功能正确性。引入 happy-dom 作为测试环境依赖。