### PR TITLE
feat(types): 添加PromiseFunction及其相关类型工具

### DIFF
--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnyFunction } from './global'
 
 /**
@@ -26,4 +27,25 @@ export type AppendArgument<Func extends AnyFunction, Arg> = Func extends (
   ...args: infer Args
 ) => infer ReturnType
   ? (...args: [...Args, Arg]) => ReturnType
+  : never
+
+export type PromiseFunction<Args extends any[] = any[], R = any> = (
+  ...args: Args
+) => Promise<R>
+/**
+ * 获取Promise函数的返回值类型
+ */
+export type PromiseReturnType<Func extends PromiseFunction> = Func extends (
+  ...args: any
+) => Promise<infer R>
+  ? R
+  : never
+
+/**
+ * 获取Promise函数的参数类型
+ */
+export type PromiseParameterType<Func extends PromiseFunction> = Func extends (
+  ...args: infer Args
+) => Promise<any>
+  ? Args
   : never

--- a/test/types/function.test-d.ts
+++ b/test/types/function.test-d.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { AppendArgument, ParameterType } from '@mudssky/jsutils'
+import type {
+  AppendArgument,
+  ParameterType,
+  PromiseParameterType,
+  PromiseReturnType,
+} from '@mudssky/jsutils'
 import { assertType, test } from 'vitest'
 
 let n!: never
@@ -28,4 +33,14 @@ test('test ThisParameterType', () => {
 test('test AppendArgument', () => {
   const fn = () => {}
   assertType<AppendArgument<typeof fn, string>>((ll: string) => {})
+})
+
+test('test PromiseReturnType', () => {
+  const asyncFn = async () => 'hello'
+  assertType<PromiseReturnType<typeof asyncFn>>('hello')
+})
+
+test('test PromiseParameterType', () => {
+  const asyncFn = async (a: string, b: number) => a + b
+  assertType<PromiseParameterType<typeof asyncFn>>(['test', 123])
 })


### PR DESCRIPTION
新增PromiseFunction类型以及PromiseReturnType和PromiseParameterType工具类型，用于处理Promise函数的返回值和参数类型。同时更新了相关测试用例以验证新类型的正确性。